### PR TITLE
Programmatic Model Creation with Ollama API, Parameterized System Prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a FastAPI server that integrates with Ollama's Python API to pro
 
 - Python 3.10+
 - `pip` (Python package installer)
-- Ollama CLI
+- Ollama
 
 ## Installation
 
@@ -17,7 +17,7 @@ This project is a FastAPI server that integrates with Ollama's Python API to pro
     ```
 
 2. Install the Ollama CLI:
-    Follow the instructions on the [Ollama website](https://ollama.com) to install the Ollama CLI.
+    Follow the instructions on the [Ollama website](https://ollama.com) to install Ollama
 
 3. Create and activate a virtual environment, and install the dependencies:
     ```sh

--- a/prompts/default_system_prompt.txt
+++ b/prompts/default_system_prompt.txt
@@ -1,0 +1,7 @@
+You are OllamaGPT, an advanced AI assistant designed to provide helpful, accurate, and engaging responses to user inquiries. You are knowledgeable in a wide range of topics, including but not limited to technology, science, history, entertainment, and programming. Your responses should be clear, well-structured, and tailored to the user's intent.
+
+Maintain a friendly and professional tone while adapting to the user's preferences. If a user asks for explanations, provide them at the appropriate level of detail. When responding to technical questions, ensure accuracy and relevance, and cite best practices where applicable. If a question requires up-to-date information, leverage external tools or indicate potential limitations.
+
+If a user asks for creative writing, code generation, or strategic advice, provide high-quality and well-thought-out responses. When handling complex or ambiguous requests, ask clarifying questions to better understand the user’s needs.
+
+You should always strive to be helpful, concise, and engaging, avoiding unnecessary repetition or verbosity. If a request is unclear, politely ask for clarification.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,15 +13,6 @@ export OLLAMA_MODEL=$MODEL
 
 # Function to clean up background processes
 cleanup() {
-    if [ -n "$OLLAMA_PID" ] && ps -p $OLLAMA_PID > /dev/null; then
-        echo "Stopping Ollama process..."
-        kill $OLLAMA_PID
-        wait $OLLAMA_PID
-        echo "Ollama process stopped."
-    else
-        echo "Ollama process already stopped or PID not set."
-    fi
-
     if [ -n "$PROMETHEUS_PID" ] && ps -p $PROMETHEUS_PID > /dev/null; then
         echo "Stopping Prometheus process..."
         kill $PROMETHEUS_PID
@@ -34,11 +25,6 @@ cleanup() {
 
 # Set trap to catch termination signals and clean up
 trap cleanup EXIT
-
-# Run the Ollama command in a separate process
-ollama run $MODEL &
-OLLAMA_PID=$!
-echo "Ollama process started with PID $OLLAMA_PID"
 
 # Check if Prometheus should be started
 START_PROMETHEUS=${2:-true}

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -23,7 +23,7 @@ def load_system_prompt(file_path: str) -> str:
         logger.error(f"Error loading system prompt from {file_path}: {str(e)}")
         raise
 
-# Create the model on the executor
+# Create the model on the executor - executed at startup
 def create_model():
     try:
         system_prompt = load_system_prompt("prompts/default_system_prompt.txt")
@@ -33,4 +33,11 @@ def create_model():
         logger.error(f"Error creating model {MODEL_NAME}: {str(e)}")
         raise
 
-create_model()
+# Delete the model on the executor - executed at shutdown
+def delete_model():
+    try:
+        ollama.delete(model="ollama-fastapi-rs-model")
+        logger.info(f"Model {MODEL_NAME} deleted successfully.")
+    except Exception as e:
+        logger.error(f"Error deleting model {MODEL_NAME}: {str(e)}")
+        raise

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,4 +1,5 @@
 import os
+import ollama
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -12,3 +13,24 @@ limiter = Limiter(key_func=get_remote_address)
 
 # Model name configuration
 MODEL_NAME = os.getenv("OLLAMA_MODEL", "deepseek-r1:1.5b")
+
+# Load the system prompt from a file
+def load_system_prompt(file_path: str) -> str:
+    try:
+        with open(file_path, 'r') as file:
+            return file.read()
+    except Exception as e:
+        logger.error(f"Error loading system prompt from {file_path}: {str(e)}")
+        raise
+
+# Create the model on the executor
+def create_model():
+    try:
+        system_prompt = load_system_prompt("prompts/default_system_prompt.txt")
+        ollama.create(model="ollama-fastapi-rs-model", from_=MODEL_NAME, system=system_prompt)
+        logger.info(f"Model {MODEL_NAME} created successfully.")
+    except Exception as e:
+        logger.error(f"Error creating model {MODEL_NAME}: {str(e)}")
+        raise
+
+create_model()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI, Request
+from fastapi.concurrency import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from prometheus_fastapi_instrumentator import Instrumentator
-from .config import limiter
+from .config import create_model, delete_model, limiter
 from .routes import router
 
 app = FastAPI()
@@ -26,6 +27,12 @@ app.add_middleware(
 )
 
 app.include_router(router)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    create_model() # Create the model on startup
+    yield
+    delete_model() # Delete the model on shutdown
 
 # Instrument FastAPI application
 Instrumentator().instrument(app).expose(app)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,14 +12,6 @@ def reset_rate_limit():
 
 @patch('src.app.routes.ollama.chat')
 @patch('src.app.config.ollama.create')
-def test_get_root(mock_create, mock_chat):
-    mock_chat.return_value = [{"message": {"content": "Health check response"}}]
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Ollama FastAPI server is running!"}
-
-@patch('src.app.routes.ollama.chat')
-@patch('src.app.config.ollama.create')
 def test_post_chat(mock_create, mock_chat):
     mock_chat.return_value = [
         {"message": {"content": "Hello, user!"}},

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,37 +10,35 @@ def reset_rate_limit():
     # Reset the rate limit state before each test
     app.state.limiter.reset()
 
-@pytest.fixture
-def patched_ollama_functions():
-    with patch('src.app.routes.ollama.chat') as mock_chat, patch('src.app.config.ollama.create'):
-        def _mock_chat(response: str):
-            mock_chat.return_value = [
-                {"message": {"content": response}}
-            ]
-            return mock_chat
-        yield _mock_chat
-
-def test_get_root(patched_ollama_functions):
-    mock_chat = patched_ollama_functions("Health check response")
+@patch('src.app.routes.ollama.chat')
+@patch('src.app.config.ollama.create')
+def test_get_root(mock_create, mock_chat):
+    mock_chat.return_value = [{"message": {"content": "Health check response"}}]
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Ollama FastAPI server is running!"}
 
-def test_post_chat(patched_ollama_functions):
-        mock_chat = patched_ollama_functions("Hello, user!")
+@patch('src.app.routes.ollama.chat')
+@patch('src.app.config.ollama.create')
+def test_post_chat(mock_create, mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Hello, user!"}},
+        {"message": {"content": "How can I help you?"}}
+    ]
 
-        payload = {"prompt": "Hello, LLM!"}
-        response = client.post("/chat", json=payload)
-        assert response.status_code == 200
+    payload = {"prompt": "Hello, LLM!"}
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 200
 
-        # Read the streaming response content
-        response_content = ""
-        for chunk in response.iter_text():
-            response_content += chunk
+    # Read the streaming response content
+    response_content = ""
+    for chunk in response.iter_text():
+        response_content += chunk
 
-        assert response_content  # Ensure the response content is not empty
-        assert isinstance(response_content, str)
-        assert "Hello, user!" in response_content
+    assert response_content  # Ensure the response content is not empty
+    assert isinstance(response_content, str)
+    assert "Hello, user!" in response_content
+    assert "How can I help you?" in response_content
 
 def test_post_chat_validation():
     # Test with an invalid prompt (too short)
@@ -53,26 +51,36 @@ def test_post_chat_validation():
     response = client.post("/chat", json=payload)
     assert response.status_code == 422  # Unprocessable Entity
 
-def test_rate_limiting(patched_ollama_functions):
-        mock_chat = patched_ollama_functions("Hello, user!")
+@patch('src.app.routes.ollama.chat')
+@patch('src.app.config.ollama.create')
+def test_rate_limiting(mock_create, mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Hello, user!"}}
+    ]
 
-        payload = {"prompt": "Hello, LLM!"}
-        for _ in range(5):
-            response = client.post("/chat", json=payload)
-            assert response.status_code == 200
-
-        # The 6th request should be rate limited
+    payload = {"prompt": "Hello, LLM!"}
+    for _ in range(5):
         response = client.post("/chat", json=payload)
-        assert response.status_code == 429  # Too Many Requests
+        assert response.status_code == 200
 
-def test_health_check(patched_ollama_functions):
-    mock_chat = patched_ollama_functions("Health check response")
+    # The 6th request should be rate limited
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 429  # Too Many Requests
+
+@patch('src.app.routes.ollama.chat')
+@patch('src.app.config.ollama.create')
+def test_health_check(mock_create, mock_chat):
+    mock_chat.return_value = [{"message": {"content": "Health check response"}}]
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Ollama FastAPI server is running!"}
 
-def test_post_chat_bypass_validation(patched_ollama_functions):
-    mock_chat = patched_ollama_functions("Bypassing validation response")
+@patch('src.app.routes.ollama.chat')
+@patch('src.app.config.ollama.create')
+def test_post_chat_bypass_validation(mock_create, mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Bypassing validation response"}}
+    ]
     payload = {"prompt": "This should bypass validation."}
     response = client.post("/chat", json=payload, headers={"bypass_validation": "true"})
     assert response.status_code == 200

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,8 +11,8 @@ def reset_rate_limit():
     app.state.limiter.reset()
 
 @patch('src.app.routes.ollama.chat')
-@patch('src.app.config.ollama.create')
-def test_post_chat(mock_create, mock_chat):
+@patch('src.app.config.create_model')
+def test_post_chat(mock_create_model, mock_chat):
     mock_chat.return_value = [
         {"message": {"content": "Hello, user!"}},
         {"message": {"content": "How can I help you?"}}
@@ -44,8 +44,8 @@ def test_post_chat_validation():
     assert response.status_code == 422  # Unprocessable Entity
 
 @patch('src.app.routes.ollama.chat')
-@patch('src.app.config.ollama.create')
-def test_rate_limiting(mock_create, mock_chat):
+@patch('src.app.config.create_model')
+def test_rate_limiting(mock_create_model, mock_chat):
     mock_chat.return_value = [
         {"message": {"content": "Hello, user!"}}
     ]
@@ -60,16 +60,16 @@ def test_rate_limiting(mock_create, mock_chat):
     assert response.status_code == 429  # Too Many Requests
 
 @patch('src.app.routes.ollama.chat')
-@patch('src.app.config.ollama.create')
-def test_health_check(mock_create, mock_chat):
+@patch('src.app.config.create_model')
+def test_health_check(mock_create_model, mock_chat):
     mock_chat.return_value = [{"message": {"content": "Health check response"}}]
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Ollama FastAPI server is running!"}
 
 @patch('src.app.routes.ollama.chat')
-@patch('src.app.config.ollama.create')
-def test_post_chat_bypass_validation(mock_create, mock_chat):
+@patch('src.app.config.create_model')
+def test_post_chat_bypass_validation(mock_create_model, mock_chat):
     mock_chat.return_value = [
         {"message": {"content": "Bypassing validation response"}}
     ]


### PR DESCRIPTION
Removed Ollama model creation/process management in `scripts/start.sh`. Added functionality for Ollama model creation at server startup in `src/config.py`, which loads a default system prompt stored in the new `prompts/` directory.