### PR TITLE
Improved Test Coverage, Model Naming Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 venv
 data
 node_modules
+.coverage
+htmlcov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2024.12.14
 charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
+coverage==7.6.12
 Deprecated==1.2.18
 fastapi==0.115.7
 h11==0.14.0
@@ -20,6 +21,7 @@ prometheus_client==0.21.1
 pydantic==2.10.6
 pydantic_core==2.27.2
 pytest==8.3.4
+pytest-cov==6.0.0
 PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.6

--- a/src/app/ollama_utils.py
+++ b/src/app/ollama_utils.py
@@ -4,7 +4,8 @@ from tqdm import tqdm
 from .config import logger
 
 # Model name configuration
-MODEL_NAME = os.getenv("OLLAMA_MODEL", "deepseek-r1:1.5b")
+BASE_MODEL_NAME = os.getenv("OLLAMA_MODEL", "deepseek-r1:1.5b")
+SESSION_MODEL_NAME = "ollama-fastapi-rs-model"
 
 # Load the system prompt from a file
 def load_system_prompt(file_path: str) -> str:
@@ -25,18 +26,18 @@ def create_model():
     This function checks if the base model is already present. If not, it downloads the model.
     """
     try:
-        if model_present(MODEL_NAME):
+        if model_present(BASE_MODEL_NAME):
             system_prompt = load_system_prompt("prompts/default_system_prompt.txt")
-            ollama.create(model="ollama-fastapi-rs-model", from_=MODEL_NAME, system=system_prompt)
-            logger.info(f"Model {MODEL_NAME} created successfully.")
+            ollama.create(model="ollama-fastapi-rs-model", from_=BASE_MODEL_NAME, system=system_prompt)
+            logger.info(f"Model {SESSION_MODEL_NAME} created successfully.")
         else:
-            logger.warning(f"Model {MODEL_NAME} is not present. Downloading model.")
-            download_model(MODEL_NAME)
+            logger.warning(f"Model {BASE_MODEL_NAME} is not present. Downloading base model...")
+            download_model(BASE_MODEL_NAME)
             system_prompt = load_system_prompt("prompts/default_system_prompt.txt")
-            ollama.create(model="ollama-fastapi-rs-model", from_=MODEL_NAME, system=system_prompt)
-            logger.info(f"Model {MODEL_NAME} created successfully after downloading.")
+            ollama.create(model="ollama-fastapi-rs-model", from_=BASE_MODEL_NAME, system=system_prompt)
+            logger.info(f"Model {SESSION_MODEL_NAME} created successfully after downloading {BASE_MODEL_NAME}.")
     except Exception as e:
-        logger.error(f"Error creating model {MODEL_NAME}: {str(e)}")
+        logger.error(f"Error creating model {SESSION_MODEL_NAME}: {str(e)}")
         raise
 
 def delete_model():
@@ -45,13 +46,13 @@ def delete_model():
     This function is called during the shutdown of the FastAPI application.
     """
     try:
-        ollama.delete(model="ollama-fastapi-rs-model")
+        ollama.delete(model=f"{SESSION_MODEL_NAME}")
         logger.info(f"Model deleted successfully.")
     except Exception as e:
-        logger.error(f"Error deleting model {MODEL_NAME}: {str(e)}")
+        logger.error(f"Error deleting model {SESSION_MODEL_NAME}: {str(e)}")
         raise
 
-def model_present(model_name: str) -> bool:
+def model_present(base_model_name: str) -> bool:
     """
     Check if the specified model is present in the list of available models.
     Returns True if the model is present, False otherwise.
@@ -60,27 +61,28 @@ def model_present(model_name: str) -> bool:
         listResponse: ollama.ListResponse = ollama.list()
         logger.info(f"Available models: {listResponse.models}")
         for model in listResponse.models:
-            if model.model == model_name:
-                logger.info(f"Model {model_name} is present.")
+            if model.model == base_model_name:
+                logger.info(f"Model {base_model_name} is present.")
                 return True
     except Exception as e:
         logger.error(f"Error checking list of available models: {str(e)}")
+        return False
 
-def download_model(model_name: str) -> None:
+def download_model(base_model_name: str) -> None:
     """
     Download the specified model using the ollama library.
     This function streams the download progress and logs it using tqdm.
     """
     try:
-        logger.info(f"Downloading model {model_name}...")
+        logger.info(f"Downloading model {base_model_name}...")
         current_digest, bars = "", {}
-        for progress in ollama.pull(model=model_name, stream=True):
+        for progress in ollama.pull(model=base_model_name, stream=True):
             digest = progress.get("digest", "")
             if digest != current_digest and current_digest in bars:
                 bars[current_digest].close()
 
             if not digest:
-                logger.info(f"Downloading {model_name}, status: {progress.get('status')}")
+                logger.info(f"Downloading {base_model_name}, status: {progress.get('status')}")
 
             if digest not in bars and (total := progress.get('total')):
                 bars[digest] = tqdm(total=total, desc=f"Pulling digest {digest[7:19]}", unit='B', unit_scale=True)
@@ -88,7 +90,7 @@ def download_model(model_name: str) -> None:
             if completed := progress.get('completed'):
                 bars[digest].update(completed - bars[digest].n)
             current_digest = digest
-        logger.info(f"Model {model_name} downloaded successfully.")
+        logger.info(f"Model {base_model_name} downloaded successfully.")
     except Exception as e:
-        logger.error(f"Error downloading model {model_name}: {str(e)}")
+        logger.error(f"Error downloading model {base_model_name}: {str(e)}")
         raise

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -28,15 +28,12 @@ async def chat_stream(request: Request, prompt_request: PromptRequest, bypass_va
     try:
         if bypass_validation and bypass_validation.lower() == "true":
             logger.info("Bypassing validation due to header flag")
-            prompt = request.json().get("prompt")
+            prompt = (await request.json()).get("prompt")
         else:
             prompt = prompt_request.prompt
         logger.info(f"Received prompt: {prompt}")
         return StreamingResponse(generate_stream(prompt), media_type="text/plain")
     except HTTPException as e:
-        logger.error(f"HTTPException: {str(e)}")
-        raise e
-    except Exception as e:
         logger.error(f"Exception: {str(e)}")
         raise HTTPException(status_code=500, detail="Error processing prompt")
 
@@ -50,7 +47,7 @@ def root():
             return {"message": "Ollama FastAPI server is running!"}
         else:
             logger.error("Ollama server is not responding")
-            raise HTTPException(status_code=500, detail="Ollama server is not responding")
+            raise HTTPException
     except Exception as e:
         logger.error(f"Health check failed: {str(e)}")
         raise HTTPException(status_code=500, detail="Health check failed")

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -3,7 +3,7 @@ from fastapi.responses import StreamingResponse
 import ollama
 from typing import AsyncGenerator, Optional
 from .config import logger, limiter
-from .ollama_utils import MODEL_NAME
+from .ollama_utils import SESSION_MODEL_NAME
 from .models import PromptRequest
 from .metrics import ollama_requests_total, ollama_errors_total, ollama_response_time
 import time
@@ -14,7 +14,7 @@ async def generate_stream(prompt: str) -> AsyncGenerator[str, None]:
     try:
         start_time = time.time()
         ollama_requests_total.inc()
-        for chunk in ollama.chat(model=MODEL_NAME, messages=[{"role": "user", "content": prompt}], stream=True):
+        for chunk in ollama.chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": prompt}], stream=True):
             yield chunk["message"]["content"]
         ollama_response_time.set(time.time() - start_time)
     except Exception as e:
@@ -44,7 +44,7 @@ async def chat_stream(request: Request, prompt_request: PromptRequest, bypass_va
 def root():
     try:
         test_prompt = "Health check"
-        response = ollama.chat(model=MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
+        response = ollama.chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
         if response:
             logger.info("Ollama server is running")
             return {"message": "Ollama FastAPI server is running!"}

--- a/tests/test_ollama_utils.py
+++ b/tests/test_ollama_utils.py
@@ -1,0 +1,80 @@
+from pytest import raises
+from unittest.mock import patch, mock_open, MagicMock
+from src.app.ollama_utils import load_system_prompt, create_model, delete_model, model_present, download_model
+
+@patch("builtins.open", new_callable=mock_open, read_data="System prompt content")
+def test_load_system_prompt(mock_file):
+    file_path = "prompts/default_system_prompt.txt"
+    content = load_system_prompt(file_path)
+    assert content == "System prompt content"
+    mock_file.assert_called_once_with(file_path, 'r')
+
+@patch("builtins.open", side_effect=Exception("File not found"))
+def test_load_system_prompt_exception(mock_file):
+    file_path = "prompts/non_existent_file.txt"
+    with raises(Exception, match="File not found"):
+        load_system_prompt(file_path)
+    mock_file.assert_called_once_with(file_path, 'r')
+
+@patch("src.app.ollama_utils.ollama.create")
+@patch("src.app.ollama_utils.model_present", return_value=True)
+@patch("src.app.ollama_utils.load_system_prompt", return_value="System prompt content")
+def test_create_model(mock_load_system_prompt, mock_model_present, mock_ollama_create):
+    create_model()
+    mock_model_present.assert_called_once_with("deepseek-r1:1.5b")
+    mock_load_system_prompt.assert_called_once_with("prompts/default_system_prompt.txt")
+    mock_ollama_create.assert_called_once_with(model="ollama-fastapi-rs-model", from_="deepseek-r1:1.5b", system="System prompt content")
+
+@patch("src.app.ollama_utils.ollama.create")
+@patch("src.app.ollama_utils.download_model")
+@patch("src.app.ollama_utils.model_present", return_value=False)
+@patch("src.app.ollama_utils.load_system_prompt", return_value="System prompt content")
+def test_create_model_else_branch(mock_load_system_prompt, mock_model_present, mock_download_model, mock_ollama_create):
+    create_model()
+    mock_model_present.assert_called_once_with("deepseek-r1:1.5b")
+    mock_download_model.assert_called_once_with("deepseek-r1:1.5b")
+    mock_load_system_prompt.assert_called_once_with("prompts/default_system_prompt.txt")
+    mock_ollama_create.assert_called_once_with(model="ollama-fastapi-rs-model", from_="deepseek-r1:1.5b", system="System prompt content")
+
+@patch("src.app.ollama_utils.ollama.create", side_effect=Exception("Creation error"))
+@patch("src.app.ollama_utils.model_present", return_value=True)
+@patch("src.app.ollama_utils.load_system_prompt", return_value="System prompt content")
+def test_create_model_exception(mock_load_system_prompt, mock_model_present, mock_ollama_create):
+    with raises(Exception, match="Creation error"):
+        create_model()
+    mock_model_present.assert_called_once_with("deepseek-r1:1.5b")
+    mock_load_system_prompt.assert_called_once_with("prompts/default_system_prompt.txt")
+    mock_ollama_create.assert_called_once_with(model="ollama-fastapi-rs-model", from_="deepseek-r1:1.5b", system="System prompt content")
+
+@patch("src.app.ollama_utils.ollama.delete")
+def test_delete_model(mock_ollama_delete):
+    delete_model()
+    mock_ollama_delete.assert_called_once_with(model="ollama-fastapi-rs-model")
+
+@patch("src.app.ollama_utils.ollama.delete", side_effect=Exception("Deletion error"))
+def test_delete_model_exception(mock_ollama_delete):
+    with raises(Exception, match="Deletion error"):
+        delete_model()
+    mock_ollama_delete.assert_called_once_with(model="ollama-fastapi-rs-model")
+
+@patch("src.app.ollama_utils.ollama.list")
+def test_model_present(mock_ollama_list):
+    mock_list_response = MagicMock()
+    mock_list_response.models = [MagicMock(model="deepseek-r1:1.5b")]
+    mock_ollama_list.return_value = mock_list_response
+
+    assert model_present("deepseek-r1:1.5b") is True
+    mock_ollama_list.assert_called_once()
+
+@patch("src.app.ollama_utils.ollama.list", side_effect=Exception("List error"))
+def test_model_present_exception(mock_ollama_list):
+    result = model_present("deepseek-r1:1.5b")
+    assert result is False
+    mock_ollama_list.assert_called_once()
+
+@patch("src.app.ollama_utils.tqdm")
+@patch("src.app.ollama_utils.ollama.pull", return_value=[{"digest": "digest_1234567890", "total": 100, "completed": 50}])
+def test_download_model(mock_ollama_pull, mock_tqdm):
+    download_model("deepseek-r1:1.5b")
+    mock_ollama_pull.assert_called_once_with(model="deepseek-r1:1.5b", stream=True)
+    mock_tqdm.assert_called_once_with(total=100, desc="Pulling digest 1234567890", unit='B', unit_scale=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,102 @@
+from fastapi import HTTPException
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from src.app.main import app
+from src.app.routes import generate_stream
+
+client = TestClient(app)
+
+@pytest.mark.asyncio
+@patch("src.app.routes.ollama.chat")
+async def test_generate_stream(mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Hello, user!"}},
+        {"message": {"content": "How can I help you?"}}
+    ]
+    prompt = "Hello, LLM!"
+    stream = generate_stream(prompt)
+    result = [chunk async for chunk in stream]
+    assert result == ["Hello, user!", "How can I help you?"]
+
+@pytest.mark.asyncio
+@patch("src.app.routes.ollama.chat", side_effect=Exception("Stream error"))
+async def test_generate_stream_exception(mock_chat):
+    prompt = "Hello, LLM!"
+    with pytest.raises(HTTPException) as exc_info:
+        stream = generate_stream(prompt)
+        result = [chunk async for chunk in stream]
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Error generating stream"
+
+@patch("src.app.routes.ollama.chat")
+def test_chat_stream(mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Hello, user!"}},
+        {"message": {"content": "How can I help you?"}}
+    ]
+    payload = {"prompt": "Hello, LLM!"}
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 200
+
+    # Read the streaming response content
+    response_content = ""
+    for chunk in response.iter_text():
+        response_content += chunk
+
+    assert response_content  # Ensure the response content is not empty
+    assert isinstance(response_content, str)
+    assert "Hello, user!" in response_content
+    assert "How can I help you?" in response_content
+
+@pytest.mark.asyncio
+@patch("src.app.routes.ollama.chat")
+async def test_chat_stream_bypass_validation(mock_chat):
+    mock_chat.return_value = [
+        {"message": {"content": "Hello, user!"}},
+        {"message": {"content": "How can I help you?"}}
+    ]
+    payload = {"prompt": "Hello, LLM!"}
+    headers = {"bypass-validation": "true"}
+    response = client.post("/chat", json=payload, headers=headers)
+    assert response.status_code == 200
+
+    # Read the streaming response content
+    response_content = ""
+    for chunk in response.iter_text():
+        response_content += chunk
+
+    assert response_content  # Ensure the response content is not empty
+    assert isinstance(response_content, str)
+    assert "Hello, user!" in response_content
+    assert "How can I help you?" in response_content
+
+def test_chat_stream_validation():
+    # Test with an invalid prompt (too short)
+    payload = {"prompt": ""}
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 422  # Unprocessable Entity
+
+    # Test with an invalid prompt (contains bad words)
+    payload = {"prompt": "This contains badword1"}
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 422  # Unprocessable Entity
+
+@patch("src.app.routes.ollama.chat")
+def test_root(mock_chat):
+    mock_chat.return_value = [{"message": {"content": "Health check response"}}]
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Ollama FastAPI server is running!"}
+
+@patch("src.app.routes.ollama.chat", return_value=None)
+def test_root_no_response(mock_chat):
+    response = client.get("/")
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Health check failed"}
+
+@patch("src.app.routes.ollama.chat", side_effect=Exception("Health check failed"))
+def test_root_exception(mock_chat):
+    response = client.get("/")
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Health check failed"}


### PR DESCRIPTION
Added new Pytest files for unit testing of `ollama_utils` and `routes` individually. Added `pytest-cov` to the project, and ignored its artifacts. Did a slight refactor for consistent session vs. base model naming in `ollama_utils.py` and `routes.py`. Improved exception handling (although potentially a little wonky still) in `routes.py`. 