### PR TITLE
Asynchronous Refactor

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = "function"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ prometheus_client==0.21.1
 pydantic==2.10.6
 pydantic_core==2.27.2
 pytest==8.3.4
+pytest-asyncio==0.25.3
 pytest-cov==6.0.0
 PyYAML==6.0.2
 requests==2.32.3

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -38,10 +38,10 @@ async def chat_stream(request: Request, prompt_request: PromptRequest, bypass_va
         raise HTTPException(status_code=500, detail="Error processing prompt")
 
 @router.get("/")
-def root():
+async def root():
     try:
         test_prompt = "Health check"
-        response = AsyncClient().chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
+        response = await AsyncClient().chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
         if response:
             logger.info("Ollama server is running")
             return {"message": "Ollama FastAPI server is running!"}

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Header, Request
 from fastapi.responses import StreamingResponse
-import ollama
+from ollama import AsyncClient
 from typing import AsyncGenerator, Optional
 from .config import logger, limiter
 from .ollama_utils import SESSION_MODEL_NAME
@@ -8,14 +8,14 @@ from .models import PromptRequest
 from .metrics import ollama_requests_total, ollama_errors_total, ollama_response_time
 import time
 
-router = APIRouter()
+router: APIRouter = APIRouter()
 
 async def generate_stream(prompt: str) -> AsyncGenerator[str, None]:
     try:
         start_time = time.time()
         ollama_requests_total.inc()
-        for chunk in ollama.chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": prompt}], stream=True):
-            yield chunk["message"]["content"]
+        async for part in await AsyncClient().chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": prompt}], stream=True):
+            yield part["message"]["content"]
         ollama_response_time.set(time.time() - start_time)
     except Exception as e:
         ollama_errors_total.inc()
@@ -41,7 +41,7 @@ async def chat_stream(request: Request, prompt_request: PromptRequest, bypass_va
 def root():
     try:
         test_prompt = "Health check"
-        response = ollama.chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
+        response = AsyncClient().chat(model=SESSION_MODEL_NAME, messages=[{"role": "user", "content": test_prompt}], stream=False)
         if response:
             logger.info("Ollama server is running")
             return {"message": "Ollama FastAPI server is running!"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 from src.app.main import app
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 client = TestClient(app)
 
@@ -10,13 +10,13 @@ def reset_rate_limit():
     # Reset the rate limit state before each test
     app.state.limiter.reset()
 
-@patch('src.app.routes.ollama.chat')
+@patch('src.app.routes.AsyncClient.chat', new_callable=AsyncMock)
 @patch('src.app.ollama_utils.create_model')
-def test_post_chat(mock_create_model, mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Hello, user!"}},
-        {"message": {"content": "How can I help you?"}}
-    ]
+async def test_post_chat(mock_create_model, mock_chat):
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user!"}}
+        yield {"message": {"content": "How can I help you?"}}
+    mock_chat.return_value = mock_chat_generator()
 
     payload = {"prompt": "Hello, LLM!"}
     response = client.post("/chat", json=payload)
@@ -24,7 +24,7 @@ def test_post_chat(mock_create_model, mock_chat):
 
     # Read the streaming response content
     response_content = ""
-    for chunk in response.iter_text():
+    async for chunk in response.aiter_text():
         response_content += chunk
 
     assert response_content  # Ensure the response content is not empty
@@ -43,12 +43,12 @@ def test_post_chat_validation():
     response = client.post("/chat", json=payload)
     assert response.status_code == 422  # Unprocessable Entity
 
-@patch('src.app.routes.ollama.chat')
+@patch('src.app.routes.AsyncClient.chat', new_callable=AsyncMock)
 @patch('src.app.ollama_utils.create_model')
 def test_rate_limiting(mock_create_model, mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Hello, user!"}}
-    ]
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user!"}}
+    mock_chat.return_value = mock_chat_generator()
 
     payload = {"prompt": "Hello, LLM!"}
     for _ in range(5):
@@ -59,7 +59,7 @@ def test_rate_limiting(mock_create_model, mock_chat):
     response = client.post("/chat", json=payload)
     assert response.status_code == 429  # Too Many Requests
 
-@patch('src.app.routes.ollama.chat')
+@patch('src.app.routes.AsyncClient.chat', new_callable=AsyncMock)
 @patch('src.app.ollama_utils.create_model')
 def test_health_check(mock_create_model, mock_chat):
     mock_chat.return_value = [{"message": {"content": "Health check response"}}]
@@ -67,12 +67,12 @@ def test_health_check(mock_create_model, mock_chat):
     assert response.status_code == 200
     assert response.json() == {"message": "Ollama FastAPI server is running!"}
 
-@patch('src.app.routes.ollama.chat')
+@patch('src.app.routes.AsyncClient.chat', new_callable=AsyncMock)
 @patch('src.app.ollama_utils.create_model')
 def test_post_chat_bypass_validation(mock_create_model, mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Bypassing validation response"}}
-    ]
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user! Your message is processing normally."}}
+    mock_chat.return_value = mock_chat_generator()
     payload = {"prompt": "This should bypass validation."}
     response = client.post("/chat", json=payload, headers={"bypass_validation": "true"})
     assert response.status_code == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,26 +1,26 @@
 from fastapi import HTTPException
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 from src.app.main import app
 from src.app.routes import generate_stream
 
 client = TestClient(app)
 
 @pytest.mark.asyncio
-@patch("src.app.routes.ollama.chat")
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock)
 async def test_generate_stream(mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Hello, user!"}},
-        {"message": {"content": "How can I help you?"}}
-    ]
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user!"}}
+        yield {"message": {"content": "How can I help you?"}}
+    mock_chat.return_value = mock_chat_generator()
     prompt = "Hello, LLM!"
     stream = generate_stream(prompt)
     result = [chunk async for chunk in stream]
     assert result == ["Hello, user!", "How can I help you?"]
 
 @pytest.mark.asyncio
-@patch("src.app.routes.ollama.chat", side_effect=Exception("Stream error"))
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock, side_effect=Exception("Stream error"))
 async def test_generate_stream_exception(mock_chat):
     prompt = "Hello, LLM!"
     with pytest.raises(HTTPException) as exc_info:
@@ -29,19 +29,20 @@ async def test_generate_stream_exception(mock_chat):
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Error generating stream"
 
-@patch("src.app.routes.ollama.chat")
-def test_chat_stream(mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Hello, user!"}},
-        {"message": {"content": "How can I help you?"}}
-    ]
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock)
+async def test_chat_stream(mock_chat):
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user!"}}
+        yield {"message": {"content": "How can I help you?"}}
+    mock_chat.return_value = mock_chat_generator()
+    
     payload = {"prompt": "Hello, LLM!"}
     response = client.post("/chat", json=payload)
     assert response.status_code == 200
 
     # Read the streaming response content
     response_content = ""
-    for chunk in response.iter_text():
+    async for chunk in response.aiter_text():
         response_content += chunk
 
     assert response_content  # Ensure the response content is not empty
@@ -50,12 +51,13 @@ def test_chat_stream(mock_chat):
     assert "How can I help you?" in response_content
 
 @pytest.mark.asyncio
-@patch("src.app.routes.ollama.chat")
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock)
 async def test_chat_stream_bypass_validation(mock_chat):
-    mock_chat.return_value = [
-        {"message": {"content": "Hello, user!"}},
-        {"message": {"content": "How can I help you?"}}
-    ]
+    async def mock_chat_generator(*args, **kwargs):
+        yield {"message": {"content": "Hello, user!"}}
+        yield {"message": {"content": "How can I help you?"}}
+    mock_chat.return_value = mock_chat_generator()
+    
     payload = {"prompt": "Hello, LLM!"}
     headers = {"bypass-validation": "true"}
     response = client.post("/chat", json=payload, headers=headers)
@@ -63,7 +65,7 @@ async def test_chat_stream_bypass_validation(mock_chat):
 
     # Read the streaming response content
     response_content = ""
-    for chunk in response.iter_text():
+    async for chunk in response.aiter_text():
         response_content += chunk
 
     assert response_content  # Ensure the response content is not empty
@@ -82,20 +84,20 @@ def test_chat_stream_validation():
     response = client.post("/chat", json=payload)
     assert response.status_code == 422  # Unprocessable Entity
 
-@patch("src.app.routes.ollama.chat")
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock)
 def test_root(mock_chat):
     mock_chat.return_value = [{"message": {"content": "Health check response"}}]
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Ollama FastAPI server is running!"}
 
-@patch("src.app.routes.ollama.chat", return_value=None)
+@patch("src.app.routes.AsyncClient.chat", new_callable=AsyncMock, return_value=None)
 def test_root_no_response(mock_chat):
     response = client.get("/")
     assert response.status_code == 500
     assert response.json() == {"detail": "Health check failed"}
 
-@patch("src.app.routes.ollama.chat", side_effect=Exception("Health check failed"))
+@patch("src.app.routes.AsyncClient.chat", side_effect=Exception("Health check failed"))
 def test_root_exception(mock_chat):
     response = client.get("/")
     assert response.status_code == 500


### PR DESCRIPTION
Refactored `src/main.py` and `src/routes.py` to use `ollama.AsyncClient`'s `chat()` method, rather than the default, synchronous `chat() function of the `ollama` package. This improves the server in regard to concurrent request capability.

Also refactored the corresponding unit tests to properly mock the `AsyncClient` and it's `AsyncGenerator` return type. Needed to add `pytest-asyncio` as a dependency. Noticed deprecation warning regarding Pytest configs - added a `pytest.ini` to set some defaults and address them.